### PR TITLE
feat(OREO-61): Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### Changes
- Added `.gitattributes` to enforce LF (unix-style) line endings across all text files.

### Why
To ensure consistent line endings across different operating systems and avoid CRLF vs LF issues.
