### PR TITLE
feat: add basic UI test to validate homepage logo visibility

### DIFF
--- a/cypress/e2e/pages/homePage.js
+++ b/cypress/e2e/pages/homePage.js
@@ -1,0 +1,16 @@
+// @ts-check
+/// <reference types="cypress" />
+
+export class HomePage {
+  visit() {
+    cy.visit("https://www.automationexercise.com/");
+  }
+
+  getLogo() {
+    return cy.get('img[alt="Website for automation practice"]');
+  }
+
+  getNavMenuItem(itemText) {
+    return cy.get("ul.nav.navbar-nav").contains(itemText);
+  }
+}

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,5 +1,0 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})

--- a/cypress/e2e/specs/test1.cy.js
+++ b/cypress/e2e/specs/test1.cy.js
@@ -1,0 +1,10 @@
+import { HomePage } from "../pages/homePage";
+
+const home = new HomePage();
+
+describe("Home Page", () => {
+  it("should load the homepage and display the logo", () => {
+    home.visit();
+    home.getLogo().should("be.visible");
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,4 +20,16 @@ export default defineConfig([
       },
     },
   },
+  {
+    files: ["cypress/**/*.js"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.mocha,
+        cy: "readonly",
+        Cypress: "readonly",
+      },
+    },
+  },
 ]);


### PR DESCRIPTION

## feat(ui): implement basic homepage test

### Changes

- Added `homePage.js` with visit, getLogo, and getNavMenuItem
- Created `test1.cy.js` in specs folder to validate homepage logo visibility
- Removed `spec.cy.js` (replaced by organized POM structure)

### Notes

This PR introduces the base structure for UI tests using Cypress and the Page Object Model.
