### PR TITLE
feat(api): add tests for APIs 1–14 (products, brands, search, user account)

### DIFF
--- a/cypress/e2e/specs/api/api-create.cy.js
+++ b/cypress/e2e/specs/api/api-create.cy.js
@@ -1,0 +1,42 @@
+// cypress/e2e/api/create-account-from-env.api.cy.js
+describe("API create - Create Account com dados do .env", () => {
+  it("cria ou reconhece a conta já existente", () => {
+    cy.request({
+      log: false, // não loga o body nem segredos
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: {
+        name: "QA Fixed",
+        email: Cypress.env("USER_EMAIL"),
+        password: Cypress.env("USER_PASSWORD"),
+        title: "Mr",
+        birth_date: "10",
+        birth_month: "12",
+        birth_year: "1990",
+        firstname: "QA",
+        lastname: "Fixed",
+        company: "Test Co",
+        address1: "Street 1",
+        address2: "Suite 1",
+        country: "Canada",
+        zipcode: "A1B2C3",
+        state: "State",
+        city: "City",
+        mobile_number: "+1234567890",
+      },
+    }).then(({ status, body }) => {
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+
+      // aceita criado, já existente ou 200 bugado
+      if (status === 201) {
+        expect(data.message).to.eq("User created!");
+      } else if (status === 200) {
+        expect(data.message || "").to.match(/user (created|exists)/i);
+      } else {
+        throw new Error(`Status inesperado: ${status}`);
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api1-products.api.cy.js
+++ b/cypress/e2e/specs/api/api1-products.api.cy.js
@@ -1,0 +1,34 @@
+// cypress/e2e/api/products.api.cy.js
+
+describe("API - Lista de Produtos", () => {
+  it("deve retornar 200 e uma lista de produtos", () => {
+    // 1) faz a requisição GET
+    cy.request("/api/productsList").then((response) => {
+      // 2) valida o status HTTP
+      expect(response.status).to.eq(200);
+
+      // 3) pega o body
+      let data = response.body;
+
+      // 4) se o body vier como string, converte para objeto
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+
+      // 5) o body precisa ter a chave "products"
+      expect(data).to.have.property("products");
+
+      // 6) "products" precisa ser um array
+      const list = data.products;
+      expect(Array.isArray(list)).to.be.true;
+
+      // 7) garante que tem pelo menos 1 item
+      expect(list.length).to.be.greaterThan(0);
+
+      // 8) checa campos básicos do primeiro item
+      const first = list[0];
+      expect(first).to.have.property("id");
+      expect(first).to.have.property("name");
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api10-invalid-login.cy.js
+++ b/cypress/e2e/specs/api/api10-invalid-login.cy.js
@@ -1,0 +1,33 @@
+// cypress/e2e/api/verify-login-invalid.api.cy.js
+describe("API 10 - Verify Login com credenciais inválidas", () => {
+  it("deve retornar 404 'User not found!'", () => {
+    const invalidEmail = `qa_${Date.now()}@example.com`;
+
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      failOnStatusCode: false, // aceitar 4xx sem quebrar
+      body: {
+        email: invalidEmail,
+        password: "wrong-pass",
+      },
+    }).then(({ status, body }) => {
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+
+      if (status === 404) {
+        // comportamento documentado
+        expect(data).to.have.property("message", "User not found!");
+        return;
+      }
+      if (status === 200) {
+        // flakiness: 200 com erro no body
+        expect(data).to.have.property("responseCode", 404);
+        expect(data.message).to.match(/user not found/i);
+        return;
+      }
+
+      throw new Error(`Status inesperado: ${status}`);
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api11-create-login.cy.js
+++ b/cypress/e2e/specs/api/api11-create-login.cy.js
@@ -1,0 +1,58 @@
+// cypress/e2e/api/create-account.api.cy.js
+describe("API 11 - Create/Register User Account", () => {
+  it("deve criar conta nova e mostrar todos os dados no log", () => {
+    const uniqueEmail = `test_${Date.now()}@example.com`;
+    const password = "123456";
+
+    const bodyReq = {
+      name: "QA Test XYZ",
+      email: uniqueEmail,
+      password,
+      title: "Mr",
+      birth_date: "10",
+      birth_month: "12",
+      birth_year: "1990",
+      firstname: "QA",
+      lastname: "Tester",
+      company: "Test Company",
+      address1: "123 Test Street",
+      address2: "321 Street Test",
+      country: "TestCountry",
+      zipcode: "A1B2C3",
+      state: "Test State",
+      city: "Test City",
+      mobile_number: "+1234567890",
+    };
+
+    // loga o request completo
+    cy.log("===== REQUEST BODY =====");
+    Object.entries(bodyReq).forEach(([k, v]) => cy.log(`${k}: ${v}`));
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: bodyReq,
+    }).then(({ status, body, headers }) => {
+      cy.log("===== RESPONSE STATUS =====");
+      cy.log(`status: ${status}`);
+
+      cy.log("===== RESPONSE HEADERS =====");
+      Object.entries(headers).forEach(([k, v]) => cy.log(`${k}: ${v}`));
+
+      cy.log("===== RESPONSE BODY =====");
+      cy.log(JSON.stringify(body, null, 2));
+
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+
+      if (status === 201) {
+        expect(data).to.have.property("message", "User created!");
+      } else if (status === 200) {
+        expect(data.message).to.match(/user created/i);
+      } else {
+        throw new Error(`Status inesperado: ${status}`);
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api12-delete-account.cy.js
+++ b/cypress/e2e/specs/api/api12-delete-account.cy.js
@@ -1,0 +1,32 @@
+// cypress/e2e/api/delete-account.api.cy.js
+describe("API 12 - DELETE /deleteAccount", () => {
+  it("deve deletar a conta (200)", () => {
+    const email = Cypress.env("USER_EMAIL");
+    const password = Cypress.env("USER_PASSWORD");
+
+    if (!email || !password) {
+      throw new Error("USER_EMAIL ou USER_PASSWORD ausentes no .env");
+    }
+
+    cy.request({
+      log: false, // 👈 esconde request do log
+      method: "DELETE",
+      url: "/api/deleteAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: { email, password },
+    }).then(({ status, body }) => {
+      expect(status).to.eq(200);
+
+      if (typeof body === "string") {
+        expect(body).to.match(/account deleted/i);
+      } else if (body?.message) {
+        expect(body.message).to.match(/account deleted/i);
+      } else if (typeof body?.responseCode === "number") {
+        expect(body.responseCode).to.eq(200);
+      } else {
+        throw new Error("Formato de resposta inesperado.");
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api13-update-user.cy.js
+++ b/cypress/e2e/specs/api/api13-update-user.cy.js
@@ -1,0 +1,35 @@
+// cypress/e2e/api/update-account.api.cy.js
+describe("API 13 - Update User Account", () => {
+  it("atualiza a conta do .env (simplificado)", () => {
+    const email = Cypress.env("USER_EMAIL");
+    const password = Cypress.env("USER_PASSWORD");
+
+    const bodyReq = {
+      name: "QA Updated",
+      email,
+      password, // mantém igual
+      company: "Updated Co",
+      address1: "New Street 123",
+      city: "Toronto",
+      country: "Canada",
+      mobile_number: "+1987654321",
+    };
+
+    // loga o objeto inteiro de uma vez
+    cy.log("REQUEST BODY:", JSON.stringify(bodyReq));
+
+    cy.request({
+      method: "PUT",
+      url: "/api/updateAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: bodyReq,
+    }).then(({ status, body }) => {
+      cy.log("RESPONSE:", JSON.stringify(body));
+
+      expect(status).to.eq(200);
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+      expect(data.message).to.match(/user updated/i);
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api14-get-user-email.cy.js
+++ b/cypress/e2e/specs/api/api14-get-user-email.cy.js
@@ -1,0 +1,22 @@
+// cypress/e2e/api/get-user-detail.api.cy.js
+describe("API 14 - GET user account detail by email", () => {
+  it("retorna os detalhes do usuário do .env", () => {
+    const email = Cypress.env("USER_EMAIL");
+    if (!email) throw new Error("USER_EMAIL não definido no .env");
+
+    cy.request({
+      method: "GET",
+      url: "/api/getUserDetailByEmail",
+      qs: { email }, // query string
+      failOnStatusCode: false,
+    }).then(({ status, body }) => {
+      cy.log("RESPONSE:", JSON.stringify(body, null, 2));
+
+      expect(status).to.eq(200);
+
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+      expect(data).to.have.property("user");
+      expect(data.user).to.have.property("email", email);
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api2-search-product.api.cy.js
+++ b/cypress/e2e/specs/api/api2-search-product.api.cy.js
@@ -1,0 +1,122 @@
+// cypress/e2e/api/search-product.api.cy.js
+describe("API 5 - POST To Search Product", () => {
+  it("lista TODOS os produtos quando search_product está vazio", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      body: { search_product: "" }, // vazio => traz tudo
+    }).then((res) => {
+      // 1) status
+      expect(res.status).to.eq(200);
+
+      // 2) body pode vir string
+      let data = res.body;
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+
+      // 3) valida estrutura básica
+      expect(data).to.have.property("products");
+      const list = data.products;
+      expect(Array.isArray(list)).to.be.true;
+      expect(list.length).to.be.greaterThan(0);
+
+      // 4) pega categorias únicas com um for "raiz"
+      const categorias = [];
+      for (let i = 0; i < list.length; i++) {
+        const p = list[i];
+        const cat = p.category && p.category.category; // pode ser undefined
+        if (cat && categorias.indexOf(cat) === -1) {
+          categorias.push(cat);
+        }
+      }
+
+      // 5) pega até 3 exemplos de nomes
+      const exemplos = [];
+      for (let i = 0; i < list.length && exemplos.length < 3; i++) {
+        exemplos.push(list[i].name);
+      }
+
+      // 6) logs simples
+      cy.log(`Total de produtos: ${list.length}`);
+      cy.log(`Categorias distintas: ${categorias.join(", ")}`);
+      cy.log(`Exemplos: ${exemplos.join(" | ")}`);
+    });
+  });
+
+  it('busca por "dress" (name OU category deve conter o termo)', () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      body: { search_product: "dress" },
+    }).then((res) => {
+      expect(res.status).to.eq(200);
+
+      let data = res.body;
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+
+      expect(data).to.have.property("products");
+      const list = data.products;
+      expect(Array.isArray(list)).to.be.true;
+      expect(list.length).to.be.greaterThan(0);
+
+      const term = "dress";
+      const toLower = (s) => String(s || "").toLowerCase();
+
+      list.forEach((item) => {
+        const term = "dress";
+        const toLower = (s) => String(s || "").toLowerCase();
+        const nameHas = toLower(item.name).includes(term);
+        const cat = item.category && item.category.category;
+        const catHas = toLower(cat).includes(term);
+        const match = nameHas || catHas;
+
+        if (!match) {
+          throw new Error(
+            `Item NÃO corresponde a "${term}": ${item.name} | cat=${cat}`
+          );
+        }
+      });
+    });
+  });
+  it('busca por "tops" (name OU category deve conter o termo)', () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      body: { search_product: "tops" },
+    }).then((res) => {
+      expect(res.status).to.eq(200);
+
+      let data = res.body;
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+
+      expect(data).to.have.property("products");
+      const list = data.products;
+      expect(Array.isArray(list)).to.be.true;
+      expect(list.length).to.be.greaterThan(0);
+
+      const term = "tops";
+      const toLower = (s) => String(s || "").toLowerCase();
+
+      list.forEach((item) => {
+        const nameHas = toLower(item.name).includes(term);
+        const cat = item.category && item.category.category;
+        const catHas = toLower(cat).includes(term);
+        const match = nameHas || catHas;
+
+        if (!match) {
+          throw new Error(
+            `Item NÃO corresponde a "${term}": ${item.name} | cat=${cat}`
+          );
+        }
+      });
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api3-products-get-all-brands.api.cy.js
+++ b/cypress/e2e/specs/api/api3-products-get-all-brands.api.cy.js
@@ -1,0 +1,22 @@
+describe("API 3 - GET All Brands List", () => {
+  it("deve retornar 200 e lista de brands", () => {
+    cy.request("/api/brandsList").then((res) => {
+      expect(res.status).to.eq(200);
+
+      // se body vier string, converte; se já for objeto, usa direto
+      let data = res.body;
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+
+      expect(data).to.have.property("brands"); // tem a chave
+      expect(Array.isArray(data.brands)).to.be.true; // é array
+      expect(data.brands.length).to.be.greaterThan(0); // não vazio
+
+      // sanity opcional no primeiro item
+      const first = data.brands[0];
+      expect(first).to.have.property("id");
+      expect(first).to.have.property("brand");
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api4-brands-list-invalid-method.api.cy.js
+++ b/cypress/e2e/specs/api/api4-brands-list-invalid-method.api.cy.js
@@ -1,0 +1,55 @@
+// cypress/e2e/api/brands-list-invalid-method.api.cy.js
+describe("API 4 - PUT To All Brands List (método não permitido)", () => {
+  it("deve retornar 405 e mensagem correta", () => {
+    cy.request({
+      method: "PUT",
+      url: "/api/brandsList",
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(200);
+
+      let data = res.body;
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+
+      expect(data).to.have.property("responseCode", 405);
+      expect(data).to.have.property(
+        "message",
+        "This request method is not supported."
+      );
+    });
+  });
+});
+
+// cypress/e2e/api/brands-list-invalid-method.api.cy.js
+describe("API 4 - PUT To All Brands List (método não permitido)", () => {
+  it("rejeita PUT (status 405 OU body.responseCode 405)", () => {
+    cy.request({
+      method: "PUT",
+      url: "/api/brandsList",
+      failOnStatusCode: false, // não falha automático em 4xx
+    }).then((res) => {
+      let data = res.body;
+      if (typeof data === "string") {
+        try {
+          data = JSON.parse(data);
+        } catch {}
+      }
+
+      // aceita os 2 jeitos que já vimos a API responder
+      const rejeitou =
+        res.status === 405 ||
+        (data && typeof data === "object" && data.responseCode === 405);
+
+      // precisa ter rejeitado de algum modo
+      expect(rejeitou, `status=${res.status} body=${JSON.stringify(data)}`).to
+        .be.true;
+
+      // se o body trouxe a msg, valida também
+      if (data && data.responseCode === 405) {
+        expect(String(data.message || "")).to.include("not supported");
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api5-products-list-invalid-method.api.cy.js
+++ b/cypress/e2e/specs/api/api5-products-list-invalid-method.api.cy.js
@@ -1,0 +1,33 @@
+// cypress/e2e/api/products-list-invalid-method.api.cy.js
+describe("API 2 - POST to All Products List (comportamento real)", () => {
+  it("responde 405 (no status OU no body) OU retorna products", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/productsList",
+      failOnStatusCode: false, // deixa a gente inspecionar 4xx
+    }).then((res) => {
+      // se body vier string, tenta virar objeto
+      let data = res.body;
+      if (typeof data === "string") {
+        try {
+          data = JSON.parse(data);
+        } catch {}
+      }
+
+      const metodoNaoSuportado =
+        res.status === 405 ||
+        (data && typeof data === "object" && data.responseCode === 405);
+
+      if (metodoNaoSuportado) {
+        // caminho A: rejeitou POST
+        expect(data).to.have.property("responseCode", 405);
+        expect(String(data.message || "")).to.have.length.greaterThan(0);
+      } else {
+        // caminho B: aceitou e devolveu lista
+        expect(res.status).to.eq(200);
+        expect(data).to.have.property("products");
+        expect(Array.isArray(data.products)).to.be.true;
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api6-search-no-par.cy.js
+++ b/cypress/e2e/specs/api/api6-search-no-par.cy.js
@@ -1,0 +1,62 @@
+// cypress/e2e/api/api6-search-no-par.cy.js
+describe("API 6 - Search Product sem parâmetro", () => {
+  it("retorna 400 (correto) ou 200 com lista/erro no corpo (flaky tolerado)", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      body: {}, // sem search_product
+      failOnStatusCode: false, // não falhar em 4xx
+    }).then(({ status, body }) => {
+      // body pode vir como string
+      const data =
+        typeof body === "string"
+          ? (() => {
+              try {
+                return JSON.parse(body);
+              } catch {
+                throw new Error(
+                  `Body não-JSON com status ${status}: ${String(body).slice(
+                    0,
+                    200
+                  )}`
+                );
+              }
+            })()
+          : body;
+
+      if (status === 400) {
+        // ✅ Comportamento correto (documentado)
+        expect(data).to.have.property(
+          "message",
+          "Bad request, search_product parameter is missing in POST request"
+        );
+        return;
+      }
+
+      if (status === 200) {
+        // ✅ Flaky: 200 + lista
+        if (Array.isArray(data?.products)) {
+          expect(data.products.length).to.be.greaterThan(0);
+          return;
+        }
+        // ✅ Flaky: 200 + erro no corpo
+        if (data?.message) {
+          expect(data).to.have.property("responseCode", 400);
+          expect(data.message).to.match(/missing in POST request/i);
+          return;
+        }
+        // ❌ 200 sem products nem message
+        throw new Error(
+          `200 inesperado sem products/message: ${JSON.stringify(data).slice(
+            0,
+            200
+          )}`
+        );
+      }
+
+      // ❌ Qualquer outro status
+      throw new Error(`Status inesperado: ${status}`);
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api7-verify-login.cy.js
+++ b/cypress/e2e/specs/api/api7-verify-login.cy.js
@@ -1,0 +1,21 @@
+// cypress/e2e/api/verify-login-valid.api.cy.js
+describe("API 7 - Verify Login com dados válidos", () => {
+  it("deve retornar 200 e mensagem 'User exists!'", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      body: {
+        email: Cypress.env("USER_EMAIL"),
+        password: Cypress.env("USER_PASSWORD"),
+      },
+    }).then(({ status, body }) => {
+      expect(status).to.eq(200);
+
+      // body pode vir string ou objeto
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+
+      expect(data).to.have.property("message", "User exists!");
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api8-login-no-email.cy.js
+++ b/cypress/e2e/specs/api/api8-login-no-email.cy.js
@@ -1,0 +1,32 @@
+// cypress/e2e/api/verify-login-no-email.api.cy.js
+describe("API 8 - Verify Login sem email", () => {
+  it("deve retornar erro por falta do parâmetro email", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      body: {
+        // email ausente de propósito
+        password: Cypress.env("USER_PASSWORD"),
+      },
+      failOnStatusCode: false, // não falhar automaticamente
+    }).then(({ status, body }) => {
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+
+      if (status === 400) {
+        // comportamento documentado
+        expect(data).to.have.property(
+          "message",
+          "Bad request, email or password parameter is missing in POST request."
+        );
+      } else if (status === 200) {
+        // bug conhecido: 200 mas corpo indica erro
+        expect(data).to.have.property("responseCode", 400);
+        expect(data.message).to.match(/missing in POST request/i);
+      } else {
+        // qualquer outro status inesperado
+        throw new Error(`Status inesperado: ${status}`);
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/api/api9-delete-login.cy.js
+++ b/cypress/e2e/specs/api/api9-delete-login.cy.js
@@ -1,0 +1,27 @@
+// cypress/e2e/api/verify-login-delete.api.cy.js
+describe("API 9 - DELETE /verifyLogin", () => {
+  it("deve rejeitar método DELETE com erro apropriado", () => {
+    cy.request({
+      method: "DELETE",
+      url: "/api/verifyLogin",
+      failOnStatusCode: false, // não quebrar em 4xx/5xx
+    }).then(({ status, body }) => {
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+
+      if (status === 405) {
+        // ✅ comportamento correto (doc)
+        expect(data).to.have.property(
+          "message",
+          "This request method is not supported."
+        );
+      } else if (status === 200) {
+        // ✅ bug conhecido: 200 mas corpo sinaliza erro
+        expect(data).to.have.property("responseCode", 405);
+        expect(data.message).to.match(/not supported/i);
+      } else {
+        // ❌ qualquer outro status não previsto
+        throw new Error(`Status inesperado: ${status}`);
+      }
+    });
+  });
+});

--- a/cypress/e2e/specs/personalTests/addToCart.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/addToCart.spec.cy.js
@@ -1,5 +1,5 @@
-import { ProductsPage } from "../pages/productsPage";
-import { CartPage } from "../pages/cartPage";
+import { ProductsPage } from "../../pages/productsPage";
+import { CartPage } from "../../pages/cartPage";
 
 const products = new ProductsPage();
 const cart = new CartPage();

--- a/cypress/e2e/specs/personalTests/cart-quantity.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/cart-quantity.spec.cy.js
@@ -1,6 +1,6 @@
-import { ProductsPage } from "../pages/productsPage";
-import { ProductDetailsPage } from "../pages/productDetailsPage";
-import { CartPage } from "../pages/cartPage";
+import { ProductsPage } from "../../pages/productsPage";
+import { ProductDetailsPage } from "../../pages/productDetailsPage";
+import { CartPage } from "../../pages/cartPage";
 
 const products = new ProductsPage();
 const details = new ProductDetailsPage();

--- a/cypress/e2e/specs/personalTests/checkout-smoke.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/checkout-smoke.spec.cy.js
@@ -1,8 +1,8 @@
 // @ts-check
 /// <reference types="cypress" />
 
-import { ProductsPage } from "../pages/productsPage";
-import { CartPage } from "../pages/cartPage";
+import { ProductsPage } from "../../pages/productsPage";
+import { CartPage } from "../../pages/cartPage";
 
 const products = new ProductsPage();
 const cart = new CartPage();

--- a/cypress/e2e/specs/personalTests/checkout.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/checkout.spec.cy.js
@@ -1,9 +1,9 @@
 // @ts-check
 /// <reference types="cypress" />
 
-import { ProductsPage } from "../pages/productsPage";
-import { CartPage } from "../pages/cartPage";
-import { LoginPage } from "../pages/loginPage";
+import { ProductsPage } from "../../pages/productsPage";
+import { CartPage } from "../../pages/cartPage";
+import { LoginPage } from "../../pages/loginPage";
 
 const products = new ProductsPage();
 const cart = new CartPage();

--- a/cypress/e2e/specs/personalTests/contact.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/contact.spec.cy.js
@@ -1,8 +1,8 @@
 // @ts-check
 /// <reference types="cypress" />
 
-import { HomePage } from "../pages/homePage";
-import { ContactUsPage } from "../pages/contactUsPage";
+import { HomePage } from "../../pages/homePage";
+import { ContactUsPage } from "../../pages/contactUsPage";
 
 const home = new HomePage();
 const contact = new ContactUsPage();

--- a/cypress/e2e/specs/personalTests/navbar.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/navbar.spec.cy.js
@@ -1,4 +1,4 @@
-import { HomePage } from "../pages/homePage";
+import { HomePage } from "../../pages/homePage";
 
 const home = new HomePage();
 

--- a/cypress/e2e/specs/personalTests/product-details.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/product-details.spec.cy.js
@@ -1,5 +1,5 @@
-import { ProductsPage } from "../pages/productsPage";
-import { ProductDetailsPage } from "../pages/productDetailsPage";
+import { ProductsPage } from "../../pages/productsPage";
+import { ProductDetailsPage } from "../../pages/productDetailsPage";
 
 const products = new ProductsPage();
 const productDetails = new ProductDetailsPage();

--- a/cypress/e2e/specs/personalTests/products-list.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/products-list.spec.cy.js
@@ -1,5 +1,5 @@
-import { HomePage } from "../pages/homePage";
-import { ProductsPage } from "../pages/productsPage";
+import { HomePage } from "../../pages/homePage";
+import { ProductsPage } from "../../pages/productsPage";
 
 const home = new HomePage();
 const products = new ProductsPage();

--- a/cypress/e2e/specs/personalTests/products-search.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/products-search.spec.cy.js
@@ -1,6 +1,6 @@
 // cypress/e2e/specs/products-search.spec.cy.js
 
-import { ProductsPage } from "../pages/productsPage";
+import { ProductsPage } from "../../pages/productsPage";
 
 const products = new ProductsPage();
 

--- a/cypress/e2e/specs/personalTests/removeFromCart.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/removeFromCart.spec.cy.js
@@ -1,5 +1,5 @@
-import { ProductsPage } from "../pages/productsPage";
-import { CartPage } from "../pages/cartPage";
+import { ProductsPage } from "../../pages/productsPage";
+import { CartPage } from "../../pages/cartPage";
 
 const products = new ProductsPage();
 const cart = new CartPage();

--- a/cypress/e2e/specs/personalTests/signupLogin.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/signupLogin.spec.cy.js
@@ -1,5 +1,5 @@
-import { HomePage } from "../pages/homePage";
-import { LoginPage } from "../pages/loginPage";
+import { HomePage } from "../../pages/homePage";
+import { LoginPage } from "../../pages/loginPage";
 
 const home = new HomePage();
 const login = new LoginPage();

--- a/cypress/e2e/specs/personalTests/subscription.spec.cy.js
+++ b/cypress/e2e/specs/personalTests/subscription.spec.cy.js
@@ -1,7 +1,7 @@
 // @ts-check
 /// <reference types="cypress" />
 
-import { HomePage } from "../pages/homePage";
+import { HomePage } from "../../pages/homePage";
 
 const home = new HomePage();
 

--- a/cypress/e2e/specs/personalTests/test1.cy.js
+++ b/cypress/e2e/specs/personalTests/test1.cy.js
@@ -1,4 +1,4 @@
-import { HomePage } from "../pages/homePage";
+import { HomePage } from "../../pages/homePage";
 
 const home = new HomePage();
 


### PR DESCRIPTION
## Summary
Added full API test coverage for Automation Exercise endpoints **1–14** using Cypress.

## Implemented
- **Products**
  - API 1: GET /productsList
  - API 2: POST /productsList (invalid method)
- **Brands**
  - API 3: GET /brandsList
  - API 4: PUT /brandsList (invalid method)
- **Search**
  - API 5: POST /searchProduct (positive/negative terms)
  - API 6: POST /searchProduct without parameter
- **User Account**
  - API 7: POST /verifyLogin (valid credentials)
  - API 8: POST /verifyLogin without email
  - API 9: DELETE /verifyLogin (invalid method)
  - API 10: POST /verifyLogin invalid credentials
  - API 11: POST /createAccount (unique + env user)
  - API 12: DELETE /deleteAccount (env user cleanup)
  - API 13: PUT /updateAccount (update user details)
  - API 14: GET /getUserDetailByEmail

## Notes
- Handled backend flakiness (200 instead of 4xx/405).
- Added JSON parsing when response comes as string.
- Included request/response logging for debug.
- Env user (`cypress.env.json`) used for login/account tests.