### PR TITLE
feat/pipeline: add manual GitHub Actions workflow for Cypress

### DIFF
--- a/.github/workflows/cypress-manual.yml
+++ b/.github/workflows/cypress-manual.yml
@@ -1,0 +1,41 @@
+# .github/workflows/autoTests-manual.yml
+name: AutoTests (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec_glob:
+        description: "Optional spec glob (e.g. cypress/e2e/platformTests/**/*.cy.js)"
+        required: false
+        default: ""
+
+jobs:
+  run-cypress:
+    runs-on: ubuntu-latest
+
+    env:
+      # Settings > Secrets and variables > Actions
+      CYPRESS_USER_EMAIL: ${{ secrets.CYPRESS_USER_EMAIL }}
+      CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+      CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run Cypress (manual spec or all)
+        env:
+          SPEC_GLOB: ${{ github.event.inputs.spec_glob }}
+        run: |
+          SPECS="${SPEC_GLOB:-cypress/e2e/**/*.cy.js}"
+          echo "Running specs: $SPECS"
+          npx cypress run --browser chrome --headless --spec "$SPECS"


### PR DESCRIPTION
# Add a manual GitHub Actions workflow to run Cypress on demand

**File:** `.github/workflows/autoTests-manual.yml`  
**Trigger:** `workflow_dispatch`

## Why
Avoid running the full (large) suite on every push. Run only when needed, and optionally target specific specs.

## How to run
1. Go to **Actions → AutoTests (manual)**.  
2. Choose the **branch** and optional **`spec_glob`**.  
3. Click **Run workflow**.

**Examples for `spec_glob`:**
cypress/e2e/platformTests/**/*.cy.js
cypress/e2e/api/**/*.cy.js
cypress/e2e/platformTests/tc12-add-products.cy.js

## What it does
- Uses **Node 22** with **npm cache**
- Runs `npm ci`
- Runs:
  npx cypress run --browser chrome [--spec spec_glob]
- Uploads **videos** and **screenshots** as artifacts

## Secrets used
- `CYPRESS_USER_EMAIL`
- `CYPRESS_USER_PASSWORD`
- `CYPRESS_USER_NAME`

Available in tests via `Cypress.env(...)`.
