### PR TITLE
feat: Fixing API tcs to run the pipeline properly

### DIFF
--- a/cypress/e2e/specs/api/api-create.cy.js
+++ b/cypress/e2e/specs/api/api-create.cy.js
@@ -1,3 +1,4 @@
+// cypress/e2e/specs/api/api-create.cy.js
 describe("API create - Create Account with data from .env", () => {
   it("creates or recognizes the already existing account", () => {
     cy.request({
@@ -5,7 +6,7 @@ describe("API create - Create Account with data from .env", () => {
       method: "POST",
       url: "/api/createAccount",
       form: true,
-      failOnStatusCode: false,
+      failOnStatusCode: false, // important to handle 4xx/5xx manually
       body: {
         name: "QA Fixed",
         email: Cypress.env("USER_EMAIL"),
@@ -26,15 +27,30 @@ describe("API create - Create Account with data from .env", () => {
         mobile_number: "+1234567890",
       },
     }).then(({ status, body }) => {
-      const data = typeof body === "string" ? JSON.parse(body) : body;
+      // Ensure object
+      const data = typeof body === "string" ? JSON.parse(body) : body || {};
+      const msg = String(data.message || "").toLowerCase();
 
+      // Successful creation (ideal REST: 201)
       if (status === 201) {
-        expect(data.message).to.eq("User created!");
-      } else if (status === 200) {
-        expect(data.message || "").to.match(/user (created|exists)/i);
-      } else {
-        throw new Error(`Unexpected status: ${status}`);
+        // Accepts "User created!" and simple variations
+        expect(msg).to.match(/user created!?/i);
+        return;
       }
+
+      // Already exists (many back-ends use 409; some return 200)
+      if (status === 409 || status === 200) {
+        // Robust regex covering: "Email already exists!", "User exists", etc.
+        expect(msg).to.match(
+          /(?:user|email)(?: already)? (?:created|exist)s?!?/i
+        );
+        return;
+      }
+
+      // Any other status is unexpected
+      throw new Error(
+        `Unexpected status: ${status} | message: ${data.message}`
+      );
     });
   });
 });


### PR DESCRIPTION
## Changes

### Improved resilience in account creation test (`api-create`)
- Adjusted assertions to handle both **"User created!"** and **"Email already exists!"**.  
- Added regex/predicate to tolerate variations in API messages (case sensitivity, optional "already", etc.).  
- Accepted both **201 Created** and **200/409** as valid status codes depending on API behavior.  

### Fixed user update test (`api13-update-user`)
- **Issue**: Test was failing because `api12-delete-account` removed the user before update.  
- **Solution**: Made the test self-contained:  
  - Ensures user exists before attempting `PUT /api/updateAccount`.  
  - Falls back to creating the user if **"Account not found!"** is returned.  
  - Prevents dependency on execution order of previous tests.  

---

## Benefits
- More stable test suite (no false negatives due to API response variations).  
- Tests no longer depend on execution order.  
- Better alignment with REST best practices (`201` for creation, `409` for conflict).  