### PR TITLE
feat: Add Cypress cross-browser and daily scheduled workflows

### DIFF
--- a/.github/workflows/cypress-browsers.yml
+++ b/.github/workflows/cypress-browsers.yml
@@ -1,0 +1,83 @@
+name: AutoTests (cross-browsers)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-cypress-matrix:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, edge, firefox]
+
+    env:
+      # GitHub Actions > Settings > Secrets and variables
+      CYPRESS_USER_EMAIL: ${{ secrets.CYPRESS_USER_EMAIL }}
+      CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+      CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Ensure each browser is available
+      - name: Setup Chrome
+        if: matrix.browser == 'chrome'
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Setup Edge
+        if: matrix.browser == 'edge'
+        uses: browser-actions/setup-edge@v1
+
+      - name: Setup Firefox
+        if: matrix.browser == 'firefox'
+        uses: browser-actions/setup-firefox@v1
+
+      - name: Run Cypress (${{ matrix.browser }})
+        run: |
+          echo "Running tests on ${{ matrix.browser }}"
+          npx cypress run \
+            --browser ${{ matrix.browser }} \
+            --headless \
+            --spec "cypress/e2e/**/*.cy.js" \
+            --reporter junit \
+            --reporter-options "mochaFile=results/test-[hash]-${{ matrix.browser }}.xml,toConsole=true"
+
+      # Upload artifacts per browser (useful for debugging and portfolio)
+      - name: Upload videos (${{ matrix.browser }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: videos-${{ matrix.browser }}
+          path: cypress/videos/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload screenshots (${{ matrix.browser }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-${{ matrix.browser }}
+          path: cypress/screenshots/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload JUnit results (${{ matrix.browser }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-${{ matrix.browser }}
+          path: results/*.xml
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/cypress-daily.yml
+++ b/.github/workflows/cypress-daily.yml
@@ -1,0 +1,33 @@
+name: AutoTests (daily scheduled)
+
+on:
+  schedule:
+    # Run every day at 12:00 UTC
+    - cron: "0 12 * * *"
+
+jobs:
+  run-cypress:
+    runs-on: ubuntu-latest
+
+    env:
+      CYPRESS_USER_EMAIL: ${{ secrets.CYPRESS_USER_EMAIL }}
+      CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+      CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Cypress (Chrome)
+        run: |
+          echo "Running scheduled daily tests on Chrome"
+          npx cypress run --browser chrome --headless --spec "cypress/e2e/**/*.cy.js"

--- a/cypress/e2e/specs/api/api13-update-user.cy.js
+++ b/cypress/e2e/specs/api/api13-update-user.cy.js
@@ -52,7 +52,7 @@ describe("API 13 - Update User Account", () => {
       .then(({ status, body }) => {
         const data = typeof body === "string" ? JSON.parse(body) : body;
 
-        // se a API disser "não encontrado", cria e tenta novamente
+        // if user not found, create and try again
         if (
           (status === 404 || status === 200) &&
           /account not found/i.test(String(data.message))


### PR DESCRIPTION
This PR introduces two new GitHub Actions workflows for Cypress tests:

- **Cross-browser workflow**: runs tests in parallel on Chrome, Edge, and Firefox using a matrix strategy.
- **Daily scheduled workflow**: runs all tests on Chrome every day at 12:00 UTC.

These workflows improve test coverage across multiple browsers and enable automated daily checks for reliability.
