### PR TITLE
feat: Remove workflow_dispatch inputs and simplify manual run (Chrome)

### DIFF
--- a/.github/workflows/cypress-manual.yml
+++ b/.github/workflows/cypress-manual.yml
@@ -2,11 +2,6 @@ name: AutoTests (manual)
 
 on:
   workflow_dispatch:
-    inputs:
-      spec_glob:
-        description: "Optional spec glob (e.g. cypress/e2e/platformTests/**/*.cy.js)"
-        required: false
-        default: ""
 
 jobs:
   run-cypress:
@@ -31,10 +26,7 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Run Cypress (manual spec or all)
-        env:
-          SPEC_GLOB: ${{ github.event.inputs.spec_glob }}
+      - name: Run Cypress (Chrome)
         run: |
-          SPECS="${SPEC_GLOB:-cypress/e2e/**/*.cy.js}"
-          echo "Running specs: $SPECS"
-          npx cypress run --browser chrome --headless --spec "$SPECS"
+          echo "Running all specs on Chrome"
+          npx cypress run --browser chrome --headless --spec "cypress/e2e/**/*.cy.js"


### PR DESCRIPTION
This PR updates the manual Cypress workflow to simplify its execution:

- Removed the unused `spec_glob` input from workflow_dispatch.
- Simplified the run step to always execute all tests in Chrome.
- Ensures a cleaner GitHub Actions UI (no unnecessary input field).

This change makes the workflow easier to trigger and aligns it with the new cross-browser and daily scheduled workflows.
