### PR TITLE
feat/api: Add full API test suite with factories, edge cases and payload reuse

### DIFF
--- a/cypress/e2e/specs/apiTests/api1-products.api.cy.js
+++ b/cypress/e2e/specs/apiTests/api1-products.api.cy.js
@@ -22,13 +22,4 @@ describe("API - Product List", () => {
       expect(data.responseCode).to.eq(405);
     });
   });
-
-  it("Should return 404 when hitting an invalid endpoint", () => {
-    cy.request({
-      url: "/api/asdqweasd",
-      failOnStatusCode: false,
-    }).then(({ status }) => {
-      expect(status).to.eq(404);
-    });
-  });
 });

--- a/cypress/e2e/specs/apiTests/api10-invalid-login.cy.js
+++ b/cypress/e2e/specs/apiTests/api10-invalid-login.cy.js
@@ -1,6 +1,6 @@
 import { invalidCredentials } from "../../../support/factories/userFactory";
 
-describe("API 10 - POST To Verify Login with invalid details", () => {
+describe("API 10 - POST To Verify Login with invalid data", () => {
   it("Should return responseCode 404 and message 'User not found!'", () => {
     cy.request({
       method: "POST",

--- a/cypress/e2e/specs/apiTests/api11-create-login.cy.js
+++ b/cypress/e2e/specs/apiTests/api11-create-login.cy.js
@@ -5,11 +5,8 @@ import {
 } from "../../../support/factories/userFactory";
 
 describe("API 11 - POST To Create/Register User Account", () => {
-  let payload;
-
-  before(() => {
-    payload = buildAccountPayload();
-  });
+  // Shared payload for "created" and "already exists"
+  const payload = buildAccountPayload();
 
   it("Should return 201 and message 'User created!'", () => {
     cy.request({
@@ -40,14 +37,14 @@ describe("API 11 - POST To Create/Register User Account", () => {
   });
 
   it("Should return 400 when email is missing", () => {
-    const payload = buildAccountPayload();
-    delete payload.email;
+    const invalid = buildAccountPayload();
+    delete invalid.email;
 
     cy.request({
       method: "POST",
       url: "/api/createAccount",
       form: true,
-      body: payload,
+      body: invalid,
       failOnStatusCode: false,
     }).then(({ body }) => {
       const data = JSON.parse(body);
@@ -56,14 +53,14 @@ describe("API 11 - POST To Create/Register User Account", () => {
   });
 
   it("Should return 400 when password is missing", () => {
-    const payload = buildAccountPayload();
-    delete payload.password;
+    const invalid = buildAccountPayload();
+    delete invalid.password;
 
     cy.request({
       method: "POST",
       url: "/api/createAccount",
       form: true,
-      body: payload,
+      body: invalid,
       failOnStatusCode: false,
     }).then(({ body }) => {
       const data = JSON.parse(body);
@@ -72,13 +69,13 @@ describe("API 11 - POST To Create/Register User Account", () => {
   });
 
   it("Should return 400 when required fields are empty strings", () => {
-    const payload = buildAccountPayload(accountEdgeCases.emptyFields);
+    const invalid = buildAccountPayload(accountEdgeCases.emptyFields);
 
     cy.request({
       method: "POST",
       url: "/api/createAccount",
       form: true,
-      body: payload,
+      body: invalid,
       failOnStatusCode: false,
     }).then(({ body }) => {
       const data = JSON.parse(body);
@@ -87,13 +84,13 @@ describe("API 11 - POST To Create/Register User Account", () => {
   });
 
   it("Should return 400 when email format is invalid", () => {
-    const payload = buildAccountPayload(accountEdgeCases.invalidEmailFormat);
+    const invalid = buildAccountPayload(accountEdgeCases.invalidEmailFormat);
 
     cy.request({
       method: "POST",
       url: "/api/createAccount",
       form: true,
-      body: payload,
+      body: invalid,
       failOnStatusCode: false,
     }).then(({ body }) => {
       const data = JSON.parse(body);

--- a/cypress/e2e/specs/apiTests/api12-delete-account.cy.js
+++ b/cypress/e2e/specs/apiTests/api12-delete-account.cy.js
@@ -1,4 +1,8 @@
-import { buildAccountPayload } from "../../../support/factories/userFactory";
+import {
+  buildAccountPayload,
+  invalidCredentials,
+  accountEdgeCases,
+} from "../../../support/factories/userFactory";
 
 describe("API 12 - DELETE METHOD To Delete User Account", () => {
   it("Should create and then delete the user account", () => {
@@ -31,6 +35,152 @@ describe("API 12 - DELETE METHOD To Delete User Account", () => {
         expect(data.responseCode).to.eq(201); //issue found, the doc asks to validate 200 responseCode. However, the body responseCode returns 201
         expect(deleteData.message).to.eq("Account deleted!");
       });
+    });
+  });
+
+  it("Should return 404 when password is wrong (email exists)", () => {
+    const payload = buildAccountPayload();
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      cy.request({
+        method: "DELETE",
+        url: "/api/deleteAccount",
+        form: true,
+        failOnStatusCode: false,
+        body: { email: payload.email, password: invalidCredentials.password },
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(404);
+        expect(data.message).to.eq("Account not found!");
+      });
+    });
+  });
+
+  it("Should return 404 when email does not exist (password is valid)", () => {
+    const payload = buildAccountPayload();
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      cy.request({
+        method: "DELETE",
+        url: "/api/deleteAccount",
+        form: true,
+        failOnStatusCode: false,
+        body: { email: invalidCredentials.email, password: payload.password },
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(404);
+        expect(data.message).to.eq("Account not found!");
+      });
+    });
+  });
+
+  it("Should delete successfully and then return 404 on a second delete", () => {
+    const payload = buildAccountPayload();
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      // 1st deletion
+      cy.request({
+        method: "DELETE",
+        url: "/api/deleteAccount",
+        form: true,
+        failOnStatusCode: false,
+        body: { email: payload.email, password: payload.password },
+      }).then(({ body }) => {
+        const first = JSON.parse(body);
+        expect(first.message).to.eq("Account deleted!");
+        // 2nd deletion
+        cy.request({
+          method: "DELETE",
+          url: "/api/deleteAccount",
+          form: true,
+          failOnStatusCode: false,
+          body: { email: payload.email, password: payload.password },
+        }).then(({ body }) => {
+          const second = JSON.parse(body);
+          expect(second.responseCode).to.eq(404);
+          expect(second.message).to.eq("Account not found!");
+        });
+      });
+    });
+  });
+
+  it("Should return 400 when email is missing", () => {
+    const payload = buildAccountPayload();
+    cy.request({
+      method: "DELETE",
+      url: "/api/deleteAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: { password: payload.password },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(400);
+      expect(data.message).to.eq(
+        "Bad request, email parameter is missing in DELETE request."
+      );
+    });
+  });
+
+  it("Should return 400 when password is missing", () => {
+    const payload = buildAccountPayload();
+    cy.request({
+      method: "DELETE",
+      url: "/api/deleteAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: { email: payload.email },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(400);
+      expect(data.message).to.eq(
+        "Bad request, password parameter is missing in DELETE request."
+      );
+    });
+  });
+
+  it("Should return 404 when email and password are empty strings", () => {
+    cy.request({
+      method: "DELETE",
+      url: "/api/deleteAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: accountEdgeCases.emptyFields, // { email: "", password: "" }
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(404);
+      expect(data.message).to.eq("Account not found!");
+    });
+  });
+
+  it("Should return 405 when using POST instead of DELETE", () => {
+    const payload = buildAccountPayload();
+    cy.request({
+      method: "POST",
+      url: "/api/deleteAccount",
+      form: true,
+      failOnStatusCode: false,
+      body: { email: payload.email, password: payload.password },
+    }).then(({ status, body }) => {
+      expect(status).to.eq(405);
+
+      const data = typeof body === "string" ? JSON.parse(body) : body; // in this case the API already returns body as an object ({detail: ...}), so parsing directly would break
+
+      expect(data.detail).to.eq('Method "POST" not allowed.');
     });
   });
 });

--- a/cypress/e2e/specs/apiTests/api13-update-user.cy.js
+++ b/cypress/e2e/specs/apiTests/api13-update-user.cy.js
@@ -1,6 +1,8 @@
 import {
   buildAccountPayload,
   buildUpdatedPayload,
+  invalidCredentials,
+  accountEdgeCases,
 } from "../../../support/factories/userFactory";
 
 describe("API 13 - PUT METHOD To Update User Account", () => {
@@ -29,9 +31,213 @@ describe("API 13 - PUT METHOD To Update User Account", () => {
         body: updatedPayload,
         failOnStatusCode: false,
       }).then(({ body }) => {
-        const upd = JSON.parse(body);
-        expect(upd.responseCode).to.eq(200); // responseCode from body returns 200
-        expect(upd.message).to.eq("User updated!");
+        const updData = JSON.parse(body);
+        expect(updData.responseCode).to.eq(200);
+        expect(updData.message).to.eq("User updated!");
+      });
+    });
+  });
+
+  it("Should return 404 when password is wrong (email exists)", () => {
+    const payload = buildAccountPayload();
+
+    // create first
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      // attempt update with wrong password
+      const wrongPwd = {
+        ...buildUpdatedPayload(payload),
+        password: invalidCredentials.password,
+      };
+
+      cy.request({
+        method: "PUT",
+        url: "/api/updateAccount",
+        form: true,
+        body: wrongPwd,
+        failOnStatusCode: false,
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(404);
+        expect(data.message).to.eq("Account not found!");
+      });
+    });
+  });
+
+  it("Should return 404 when email does not exist", () => {
+    const payload = buildAccountPayload();
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      const nonExistentEmailUpdate = {
+        ...buildUpdatedPayload(payload),
+        email: invalidCredentials.email, // email not registered
+      };
+
+      cy.request({
+        method: "PUT",
+        url: "/api/updateAccount",
+        form: true,
+        body: nonExistentEmailUpdate,
+        failOnStatusCode: false,
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(404);
+        expect(data.message).to.eq("Account not found!");
+      });
+    });
+  });
+
+  it("Should return 400 when email is missing", () => {
+    const payload = buildAccountPayload();
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      const noEmail = { ...buildUpdatedPayload(payload) };
+      delete noEmail.email;
+
+      cy.request({
+        method: "PUT",
+        url: "/api/updateAccount",
+        form: true,
+        body: noEmail,
+        failOnStatusCode: false,
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        // a API costuma mencionar o método na mensagem
+        expect(data.responseCode).to.eq(400);
+        expect(data.message).to.eq(
+          "Bad request, email parameter is missing in PUT request."
+        );
+      });
+    });
+  });
+
+  it("Should return 400 when password is missing", () => {
+    const payload = buildAccountPayload();
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      const noPwd = { ...buildUpdatedPayload(payload) };
+      delete noPwd.password;
+
+      cy.request({
+        method: "PUT",
+        url: "/api/updateAccount",
+        form: true,
+        body: noPwd,
+        failOnStatusCode: false,
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(400);
+        expect(data.message).to.eq(
+          "Bad request, password parameter is missing in PUT request."
+        );
+      });
+    });
+  });
+
+  it("Should return 404 when email and password are empty strings", () => {
+    const payload = buildAccountPayload();
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      const emptyCreds = {
+        ...buildUpdatedPayload(payload),
+        email: accountEdgeCases.emptyFields.email,
+        password: accountEdgeCases.emptyFields.password,
+      };
+
+      cy.request({
+        method: "PUT",
+        url: "/api/updateAccount",
+        form: true,
+        body: emptyCreds,
+        failOnStatusCode: false,
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(404);
+        expect(data.message).to.eq("Account not found!");
+      });
+    });
+  });
+
+  it("Should return 200 when only a single field is updated", () => {
+    const payload = buildAccountPayload();
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      const partial = {
+        email: payload.email,
+        password: payload.password,
+        city: "Testville",
+      };
+
+      cy.request({
+        method: "PUT",
+        url: "/api/updateAccount",
+        form: true,
+        body: partial,
+        failOnStatusCode: false,
+      }).then(({ body }) => {
+        const data = JSON.parse(body);
+        expect(data.responseCode).to.eq(200);
+        expect(data.message).to.eq("User updated!");
+      });
+    });
+  });
+
+  it("Should return 405 when using POST instead of PUT", () => {
+    const payload = buildAccountPayload();
+
+    cy.request({
+      method: "POST",
+      url: "/api/createAccount",
+      form: true,
+      body: payload,
+      failOnStatusCode: false,
+    }).then(() => {
+      cy.request({
+        method: "POST",
+        url: "/api/updateAccount",
+        form: true,
+        body: buildUpdatedPayload(payload),
+        failOnStatusCode: false,
+      }).then(({ status, body }) => {
+        expect(status).to.eq(405);
+        const data = typeof body === "string" ? JSON.parse(body) : body; // in this case the API already returns body as an object ({detail: ...}), so parsing directly would break
+
+        expect(data.detail).to.eq('Method "POST" not allowed.');
       });
     });
   });

--- a/cypress/e2e/specs/apiTests/api14-get-user-email.cy.js
+++ b/cypress/e2e/specs/apiTests/api14-get-user-email.cy.js
@@ -1,4 +1,7 @@
-import { buildAccountPayload } from "../../../support/factories/userFactory";
+import {
+  buildAccountPayload,
+  invalidCredentials,
+} from "../../../support/factories/userFactory";
 
 describe("API 14 - GET user account detail by email", () => {
   it("Should create and then fetch user detail by email", () => {
@@ -22,12 +25,56 @@ describe("API 14 - GET user account detail by email", () => {
         url: `/api/getUserDetailByEmail?email=${payload.email}`,
         failOnStatusCode: false,
       }).then(({ body }) => {
-        const detail = JSON.parse(body);
+        const data = JSON.parse(body);
 
-        expect(detail.responseCode).to.eq(200);
-        expect(detail).to.have.property("user");
-        expect(detail.user).to.have.property("email", payload.email);
+        expect(data.responseCode).to.eq(200);
+        expect(data).to.have.property("user");
+        expect(data.user).to.have.property("email", payload.email);
       });
+    });
+  });
+
+  it("Should return 404 when email does not exist", () => {
+    cy.request({
+      method: "GET",
+      url: `/api/getUserDetailByEmail?email=${invalidCredentials.email}`,
+      failOnStatusCode: false,
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+
+      expect(data.responseCode).to.eq(404);
+      expect(data.message).to.eq(
+        "Account not found with this email, try another email!"
+      );
+    });
+  });
+
+  it("Should return 400 when email parameter is missing", () => {
+    cy.request({
+      method: "GET",
+      url: "/api/getUserDetailByEmail",
+      failOnStatusCode: false,
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+
+      expect(data.responseCode).to.eq(400);
+      expect(data.message).to.eq(
+        "Bad request, email parameter is missing in GET request."
+      );
+    });
+  });
+
+  it("Should return 405 when using POST instead of GET", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/getUserDetailByEmail",
+      form: true,
+      body: { email: invalidCredentials.email },
+      failOnStatusCode: false,
+    }).then(({ body }) => {
+      const data = typeof body === "string" ? JSON.parse(body) : body;
+      expect(data.responseCode).to.eq(405);
+      expect(data.message).to.eq("This request method is not supported.");
     });
   });
 });

--- a/cypress/e2e/specs/apiTests/api2-search-product.api.cy.js
+++ b/cypress/e2e/specs/apiTests/api2-search-product.api.cy.js
@@ -11,4 +11,29 @@ describe("API 2 - POST To All Products List (invalid method)", () => {
       expect(data.message).to.eq("This request method is not supported.");
     });
   });
+
+  it("Should return 405 when using PUT instead of GET", () => {
+    cy.request({
+      method: "PUT",
+      url: "/api/productsList",
+      failOnStatusCode: false,
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+
+      expect(data.responseCode).to.eq(405);
+      expect(data.message).to.eq("This request method is not supported.");
+    });
+  });
+  it("Should return 405 when using DELETE instead of GET", () => {
+    cy.request({
+      method: "DELETE",
+      url: "/api/productsList",
+      failOnStatusCode: false,
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+
+      expect(data.responseCode).to.eq(405);
+      expect(data.message).to.eq("This request method is not supported.");
+    });
+  });
 });

--- a/cypress/e2e/specs/apiTests/api4-brands-list-invalid-method.api.cy.js
+++ b/cypress/e2e/specs/apiTests/api4-brands-list-invalid-method.api.cy.js
@@ -1,3 +1,5 @@
+import { buildBrandPayload } from "../../../support/factories/userFactory";
+
 describe("API 4 - PUT To All Brands List", () => {
   it("Should return responseCode 405 inside body with proper message", () => {
     cy.request({
@@ -7,6 +9,22 @@ describe("API 4 - PUT To All Brands List", () => {
     }).then(({ body }) => {
       const data = JSON.parse(body);
 
+      expect(data.responseCode).to.eq(405);
+      expect(data.message).to.eq("This request method is not supported.");
+    });
+  });
+
+  it("Should return responseCode 405 with proper message (using factory payload)", () => {
+    const payload = buildBrandPayload();
+
+    cy.request({
+      method: "PUT",
+      url: "/api/brandsList",
+      form: true,
+      failOnStatusCode: false,
+      body: payload,
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
       expect(data.responseCode).to.eq(405);
       expect(data.message).to.eq("This request method is not supported.");
     });

--- a/cypress/e2e/specs/apiTests/api5-search-products.api.cy.js
+++ b/cypress/e2e/specs/apiTests/api5-search-products.api.cy.js
@@ -13,4 +13,28 @@ describe("API 5 - POST To Search Product", () => {
       expect(data.products).to.be.an("array");
     });
   });
+  it("Should return 200 and a list of searched another products", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      body: { search_product: searchTerms.anotherValid },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(200);
+      expect(data.products).to.be.an("array");
+    });
+  });
+  it("Should return 200 and an empty array when searching invalid products", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      body: { search_product: searchTerms.invalid },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(200);
+      expect(data.products).to.be.an("array").that.is.empty;
+    });
+  });
 });

--- a/cypress/e2e/specs/apiTests/api6-search-no-par.cy.js
+++ b/cypress/e2e/specs/apiTests/api6-search-no-par.cy.js
@@ -1,3 +1,9 @@
+import {
+  buildSearchPayloadMissing,
+  buildSearchPayloadEmpty,
+  buildSearchPayloadWrongName,
+} from "../../../support/factories/userFactory";
+
 describe("API 6 - POST To Search Product without parameter", () => {
   it("Should return responseCode 400 with proper error message", () => {
     cy.request({
@@ -5,10 +11,39 @@ describe("API 6 - POST To Search Product without parameter", () => {
       url: "/api/searchProduct",
       form: true,
       failOnStatusCode: false,
-      body: {}, // missing search_product parameter
+      body: buildSearchPayloadMissing(),
     }).then(({ body }) => {
       const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(400);
+      expect(data.message).to.eq(
+        "Bad request, search_product parameter is missing in POST request."
+      );
+    });
+  });
 
+  it("Should return 200 and array when search_product is empty string", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      failOnStatusCode: false,
+      body: buildSearchPayloadEmpty(),
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(200);
+      expect(data.products).to.be.an("array");
+    });
+  });
+
+  it("Should return 400 when using wrong parameter name", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/searchProduct",
+      form: true,
+      failOnStatusCode: false,
+      body: buildSearchPayloadWrongName(),
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
       expect(data.responseCode).to.eq(400);
       expect(data.message).to.eq(
         "Bad request, search_product parameter is missing in POST request."

--- a/cypress/e2e/specs/apiTests/api7-verify-login.cy.js
+++ b/cypress/e2e/specs/apiTests/api7-verify-login.cy.js
@@ -1,14 +1,14 @@
-// cypress/e2e/specs/api/api7-verify-login.cy.js
-// @ts-check
-/// <reference types="cypress" />
-
-import { buildAccountPayload } from "../../../support/factories/userFactory";
+import {
+  buildAccountPayload,
+  invalidCredentials,
+  accountEdgeCases,
+} from "../../../support/factories/userFactory";
 
 describe("API 7 - Verify Login with valid data", () => {
   const payload = buildAccountPayload();
 
   before(() => {
-    // Create account
+    // Create account (happy path base)
     cy.request({
       method: "POST",
       url: "/api/createAccount",
@@ -19,19 +19,94 @@ describe("API 7 - Verify Login with valid data", () => {
   });
 
   it("Should return 200 and message 'User exists!'", () => {
-    // Act: verify login with the same credentials
     cy.request({
       method: "POST",
       url: "/api/verifyLogin",
       form: true,
-      body: {
-        email: payload.email,
-        password: payload.password,
-      },
+      body: { email: payload.email, password: payload.password },
     }).then(({ body }) => {
       const data = JSON.parse(body);
       expect(data.responseCode).to.eq(200);
       expect(data.message).to.eq("User exists!");
+    });
+  });
+
+  // Wrong password
+  it("Should return 404 when password is wrong", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      failOnStatusCode: false,
+      body: { email: payload.email, password: invalidCredentials.password },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(404);
+      expect(data.message).to.eq("User not found!");
+    });
+  });
+
+  it("Should return 404 when email is not registered", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      failOnStatusCode: false,
+      body: { email: invalidCredentials.email, password: payload.password },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(404);
+      expect(data.message).to.eq("User not found!");
+    });
+  });
+
+  it("Should return 404 when both email and password are invalid", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      failOnStatusCode: false,
+      body: {
+        email: invalidCredentials.email,
+        password: invalidCredentials.password,
+      },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(404);
+      expect(data.message).to.eq("User not found!");
+    });
+  });
+
+  it("Should return 400 when password is missing", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      failOnStatusCode: false,
+      body: { email: payload.email },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(400);
+      expect(data.message).to.eq(
+        "Bad request, email or password parameter is missing in POST request."
+      );
+    });
+  });
+
+  it("Should return 404 when email format is invalid", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/verifyLogin",
+      form: true,
+      failOnStatusCode: false,
+      body: {
+        email: accountEdgeCases.invalidEmailFormat.email,
+        password: payload.password,
+      },
+    }).then(({ body }) => {
+      const data = JSON.parse(body);
+      expect(data.responseCode).to.eq(404);
+      expect(data.message).to.eq("User not found!");
     });
   });
 });

--- a/cypress/e2e/specs/apiTests/api8-login-no-email.cy.js
+++ b/cypress/e2e/specs/apiTests/api8-login-no-email.cy.js
@@ -1,4 +1,8 @@
+import { buildAccountPayload } from "../../../support/factories/userFactory";
+
 describe("API 8 - POST To Verify Login without email parameter", () => {
+  const payload = buildAccountPayload();
+
   it("Should return responseCode 400 with proper error message", () => {
     cy.request({
       method: "POST",
@@ -6,12 +10,11 @@ describe("API 8 - POST To Verify Login without email parameter", () => {
       form: true,
       failOnStatusCode: false,
       body: {
-        password: Cypress.env("USER_PASSWORD"), // missing email
+        password: payload.password, // missing email
       },
     }).then(({ body }) => {
       const data = JSON.parse(body);
 
-      // Error code and message inside body
       expect(data.responseCode).to.eq(400);
       expect(data.message).to.eq(
         "Bad request, email or password parameter is missing in POST request."

--- a/cypress/support/factories/userFactory.js
+++ b/cypress/support/factories/userFactory.js
@@ -53,3 +53,36 @@ export const accountEdgeCases = {
     email: "invalid-email-format",
   },
 };
+
+export function buildBrandPayload() {
+  return {
+    id: faker.number.int({ min: 1, max: 999999 }).toString(),
+    brand: faker.word.sample(),
+  };
+}
+
+/* -------------------------------
+   Search product payload builders
+   Purpose: keep specs free of hardcoded inputs and centralize variants.
+   These functions do not duplicate anything existing in this file.
+-------------------------------- */
+
+// Happy path payload using the already-declared searchTerms.valid
+export function buildSearchPayloadValid() {
+  return { search_product: searchTerms.valid };
+}
+
+// Missing parameter entirely -> API should return 400
+export function buildSearchPayloadMissing() {
+  return {};
+}
+
+// Parameter present but empty string -> API treats as missing (400)
+export function buildSearchPayloadEmpty() {
+  return { search_product: "" };
+}
+
+// Wrong parameter name -> API treats as missing (400)
+export function buildSearchPayloadWrongName() {
+  return { wrong_field: faker.word.sample() };
+}


### PR DESCRIPTION
This PR introduces a complete API test suite covering all available endpoints (products, brands, search, login, createAccount, deleteAccount, updateAccount, getUserDetailByEmail).

Changes

Added factories to generate dynamic payloads (accounts, brands, search inputs).

Implemented happy path tests for each endpoint.

Added multiple edge cases:

invalid methods (POST/PUT/DELETE when not supported)

missing or empty parameters (email, password, search_product)

invalid credentials and invalid email formats

double-deletion behavior and idempotency checks

partial updates and wrong payload structures

Standardized JSON parsing (JSON.parse(body) with safe fallback when needed).

Ensured payload reuse: a single instance is created at the top of the suite when multiple tests depend on the same user/email (avoiding unnecessary instantiations).